### PR TITLE
fix(config): use relative model path for shared environment #46

### DIFF
--- a/02_src/03_front/02_state/state.py
+++ b/02_src/03_front/02_state/state.py
@@ -9,7 +9,7 @@ def init_state() -> None:
         "is_sample_mode": False,
         "selected_model_name": "xgboost",
         "analysis_payload": None,
-        "model_path": r"C:\Users\Playdata\Documents\workspace\twilkka-malkka-ml\05_artifacts\00_models\model.json",
+        "model_path": r"05_artifacts/00_models/model.json",
         "high_risk_visible_count": 4,
     }
 


### PR DESCRIPTION
- state.py의 model_path를 절대경로에서 상대경로로 수정